### PR TITLE
remove 'Controller' from Persistence, Execution, Projects, Scripts contollers

### DIFF
--- a/server/app.go
+++ b/server/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MontFerret/ferret-server/server/http"
 	"github.com/MontFerret/ferret-server/server/http/api/restapi/operations"
 	"github.com/MontFerret/ferret/pkg/compiler"
+
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
@@ -138,7 +139,7 @@ func (app *Application) Run() error {
 }
 
 func (app *Application) configureProjectsController() error {
-	ctl, err := controllers.NewProjectsController(app.projects)
+	ctl, err := controllers.NewProjects(app.projects)
 
 	if err != nil {
 		return errors.Wrap(err, "new projects controller")
@@ -154,7 +155,7 @@ func (app *Application) configureProjectsController() error {
 }
 
 func (app *Application) configureScriptsController() error {
-	ctl, err := controllers.NewScriptsController(app.scripts)
+	ctl, err := controllers.NewScripts(app.scripts)
 
 	if err != nil {
 		return errors.Wrap(err, "new scripts controller")
@@ -170,7 +171,7 @@ func (app *Application) configureScriptsController() error {
 }
 
 func (app *Application) configureExecutionController() error {
-	ctl, err := controllers.NewExecutionController(app.execution, app.history)
+	ctl, err := controllers.NewExecution(app.execution, app.history)
 
 	if err != nil {
 		return errors.Wrap(err, "new execution controller")
@@ -185,7 +186,7 @@ func (app *Application) configureExecutionController() error {
 }
 
 func (app *Application) configurePersistenceController() error {
-	ctl, err := controllers.NewPersistenceController(app.persistence)
+	ctl, err := controllers.NewPersistence(app.persistence)
 
 	if err != nil {
 		return errors.Wrap(err, "new persistence controller")

--- a/server/controllers/execution.go
+++ b/server/controllers/execution.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/MontFerret/ferret-server/pkg/common"
 	"github.com/MontFerret/ferret-server/pkg/common/dal"
 	"github.com/MontFerret/ferret-server/pkg/execution"
@@ -9,15 +10,16 @@ import (
 	"github.com/MontFerret/ferret-server/server/http"
 	"github.com/MontFerret/ferret-server/server/http/api/restapi/operations"
 	"github.com/MontFerret/ferret-server/server/logging"
+
 	"github.com/go-openapi/runtime/middleware"
 )
 
-type ExecutionController struct {
+type Execution struct {
 	exec    *execution.Service
 	history *history.Service
 }
 
-func NewExecutionController(exec *execution.Service, history *history.Service) (*ExecutionController, error) {
+func NewExecution(exec *execution.Service, history *history.Service) (*Execution, error) {
 	if exec == nil {
 		return nil, common.Error(common.ErrMissedArgument, "execution service")
 	}
@@ -26,10 +28,10 @@ func NewExecutionController(exec *execution.Service, history *history.Service) (
 		return nil, common.Error(common.ErrMissedArgument, "history service")
 	}
 
-	return &ExecutionController{exec, history}, nil
+	return &Execution{exec, history}, nil
 }
 
-func (ctl *ExecutionController) Create(params operations.CreateExecutionParams) middleware.Responder {
+func (ctl *Execution) Create(params operations.CreateExecutionParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 	ctx := context.Background()
 
@@ -61,7 +63,7 @@ func (ctl *ExecutionController) Create(params operations.CreateExecutionParams) 
 	return operations.NewCreateExecutionOK().WithPayload(id)
 }
 
-func (ctl *ExecutionController) Delete(params operations.DeleteExecutionParams) middleware.Responder {
+func (ctl *Execution) Delete(params operations.DeleteExecutionParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 	ctx := context.Background()
 
@@ -86,7 +88,7 @@ func (ctl *ExecutionController) Delete(params operations.DeleteExecutionParams) 
 	return operations.NewDeleteExecutionNoContent()
 }
 
-func (ctl *ExecutionController) Find(params operations.FindExecutionsParams) middleware.Responder {
+func (ctl *Execution) Find(params operations.FindExecutionsParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 	ctx := context.Background()
 
@@ -154,7 +156,7 @@ func (ctl *ExecutionController) Find(params operations.FindExecutionsParams) mid
 	return operations.NewFindExecutionsOK().WithPayload(payload)
 }
 
-func (ctl *ExecutionController) Get(params operations.GetExecutionParams) middleware.Responder {
+func (ctl *Execution) Get(params operations.GetExecutionParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 
 	found, err := ctl.history.Get(context.Background(), params.ProjectID, params.JobID)

--- a/server/controllers/persistence.go
+++ b/server/controllers/persistence.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/MontFerret/ferret-server/pkg/common"
 	"github.com/MontFerret/ferret-server/pkg/common/dal"
 	"github.com/MontFerret/ferret-server/pkg/persistence"
@@ -10,22 +11,23 @@ import (
 	"github.com/MontFerret/ferret-server/server/http"
 	"github.com/MontFerret/ferret-server/server/http/api/restapi/operations"
 	"github.com/MontFerret/ferret-server/server/logging"
+
 	"github.com/go-openapi/runtime/middleware"
 )
 
-type PersistenceController struct {
+type Persistence struct {
 	service *persistence.Service
 }
 
-func NewPersistenceController(service *persistence.Service) (*PersistenceController, error) {
+func NewPersistence(service *persistence.Service) (*Persistence, error) {
 	if service == nil {
 		return nil, common.Error(common.ErrMissedArgument, "persistence service")
 	}
 
-	return &PersistenceController{service}, nil
+	return &Persistence{service}, nil
 }
 
-func (ctl *PersistenceController) FindAll(params operations.FindProjectDataParams) middleware.Responder {
+func (ctl *Persistence) FindAll(params operations.FindProjectDataParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 
 	var size uint = 10
@@ -78,7 +80,7 @@ func (ctl *PersistenceController) FindAll(params operations.FindProjectDataParam
 	return operations.NewFindProjectDataOK().WithPayload(payload)
 }
 
-func (ctl *PersistenceController) Find(params operations.FindScriptDataParams) middleware.Responder {
+func (ctl *Persistence) Find(params operations.FindScriptDataParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 
 	var size uint = 10
@@ -135,7 +137,7 @@ func (ctl *PersistenceController) Find(params operations.FindScriptDataParams) m
 	return operations.NewFindScriptDataOK().WithPayload(payload)
 }
 
-func (ctl *PersistenceController) Get(params operations.GetScriptDataParams) middleware.Responder {
+func (ctl *Persistence) Get(params operations.GetScriptDataParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 
 	ctx := context.Background()
@@ -174,7 +176,7 @@ func (ctl *PersistenceController) Get(params operations.GetScriptDataParams) mid
 	})
 }
 
-func (ctl *PersistenceController) Update(params operations.UpdateScriptDataParams) middleware.Responder {
+func (ctl *Persistence) Update(params operations.UpdateScriptDataParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 	ctx := context.Background()
 
@@ -204,7 +206,7 @@ func (ctl *PersistenceController) Update(params operations.UpdateScriptDataParam
 	})
 }
 
-func (ctl *PersistenceController) Delete(params operations.DeleteScriptDataParams) middleware.Responder {
+func (ctl *Persistence) Delete(params operations.DeleteScriptDataParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 	ctx := context.Background()
 

--- a/server/controllers/projects.go
+++ b/server/controllers/projects.go
@@ -8,22 +8,23 @@ import (
 	"github.com/MontFerret/ferret-server/server/http"
 	"github.com/MontFerret/ferret-server/server/http/api/restapi/operations"
 	"github.com/MontFerret/ferret-server/server/logging"
+
 	"github.com/go-openapi/runtime/middleware"
 )
 
-type ProjectsController struct {
+type Projects struct {
 	service *projects.Service
 }
 
-func NewProjectsController(service *projects.Service) (*ProjectsController, error) {
+func NewProjects(service *projects.Service) (*Projects, error) {
 	if service == nil {
 		return nil, common.Error(common.ErrMissedArgument, "exec")
 	}
 
-	return &ProjectsController{service}, nil
+	return &Projects{service}, nil
 }
 
-func (ctl *ProjectsController) CreateProject(params operations.CreateProjectParams) middleware.Responder {
+func (ctl *Projects) CreateProject(params operations.CreateProjectParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 
 	out, err := ctl.service.CreateProject(params.HTTPRequest.Context(), projects.Project{
@@ -56,7 +57,7 @@ func (ctl *ProjectsController) CreateProject(params operations.CreateProjectPara
 	})
 }
 
-func (ctl *ProjectsController) UpdateProject(params operations.UpdateProjectParams) middleware.Responder {
+func (ctl *Projects) UpdateProject(params operations.UpdateProjectParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 
 	out, err := ctl.service.UpdateProject(params.HTTPRequest.Context(), projects.UpdateProject{
@@ -94,7 +95,7 @@ func (ctl *ProjectsController) UpdateProject(params operations.UpdateProjectPara
 	})
 }
 
-func (ctl *ProjectsController) DeleteProject(params operations.DeleteProjectParams) middleware.Responder {
+func (ctl *Projects) DeleteProject(params operations.DeleteProjectParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 
 	err := ctl.service.DeleteProject(params.HTTPRequest.Context(), params.ProjectID)
@@ -117,7 +118,7 @@ func (ctl *ProjectsController) DeleteProject(params operations.DeleteProjectPara
 	return operations.NewDeleteProjectNoContent()
 }
 
-func (ctl *ProjectsController) GetProject(params operations.GetProjectParams) middleware.Responder {
+func (ctl *Projects) GetProject(params operations.GetProjectParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 
 	out, err := ctl.service.GetProject(params.HTTPRequest.Context(), params.ProjectID)
@@ -150,7 +151,7 @@ func (ctl *ProjectsController) GetProject(params operations.GetProjectParams) mi
 	})
 }
 
-func (ctl *ProjectsController) FindProjects(params operations.FindProjectsParams) middleware.Responder {
+func (ctl *Projects) FindProjects(params operations.FindProjectsParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 
 	var size uint = 10

--- a/server/controllers/scripts.go
+++ b/server/controllers/scripts.go
@@ -8,22 +8,23 @@ import (
 	"github.com/MontFerret/ferret-server/server/http"
 	"github.com/MontFerret/ferret-server/server/http/api/restapi/operations"
 	"github.com/MontFerret/ferret-server/server/logging"
+
 	"github.com/go-openapi/runtime/middleware"
 )
 
-type ScriptsController struct {
+type Scripts struct {
 	service *scripts.Service
 }
 
-func NewScriptsController(service *scripts.Service) (*ScriptsController, error) {
+func NewScripts(service *scripts.Service) (*Scripts, error) {
 	if service == nil {
 		return nil, common.Error(common.ErrMissedArgument, "exec")
 	}
 
-	return &ScriptsController{service}, nil
+	return &Scripts{service}, nil
 }
 
-func (ctl *ScriptsController) CreateScript(params operations.CreateScriptParams) middleware.Responder {
+func (ctl *Scripts) CreateScript(params operations.CreateScriptParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 
 	entity := scripts.Script{
@@ -63,7 +64,7 @@ func (ctl *ScriptsController) CreateScript(params operations.CreateScriptParams)
 	})
 }
 
-func (ctl *ScriptsController) UpdateScript(params operations.UpdateScriptParams) middleware.Responder {
+func (ctl *Scripts) UpdateScript(params operations.UpdateScriptParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 
 	script := scripts.UpdateScript{
@@ -109,7 +110,7 @@ func (ctl *ScriptsController) UpdateScript(params operations.UpdateScriptParams)
 	})
 }
 
-func (ctl *ScriptsController) DeleteScript(params operations.DeleteScriptParams) middleware.Responder {
+func (ctl *Scripts) DeleteScript(params operations.DeleteScriptParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 
 	err := ctl.service.DeleteScript(params.HTTPRequest.Context(), params.ProjectID, params.ScriptID)
@@ -134,7 +135,7 @@ func (ctl *ScriptsController) DeleteScript(params operations.DeleteScriptParams)
 	return operations.NewDeleteScriptNoContent()
 }
 
-func (ctl *ScriptsController) GetScript(params operations.GetScriptParams) middleware.Responder {
+func (ctl *Scripts) GetScript(params operations.GetScriptParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 
 	out, err := ctl.service.GetScript(params.HTTPRequest.Context(), params.ProjectID, params.ScriptID)
@@ -175,7 +176,7 @@ func (ctl *ScriptsController) GetScript(params operations.GetScriptParams) middl
 	})
 }
 
-func (ctl *ScriptsController) FindScripts(params operations.FindScriptsParams) middleware.Responder {
+func (ctl *Scripts) FindScripts(params operations.FindScriptsParams) middleware.Responder {
 	logger := logging.FromRequest(params.HTTPRequest)
 
 	var size uint = 10


### PR DESCRIPTION
`controllers.ScriptController` look redundant, so I removed `Controller`.